### PR TITLE
Add support for DateTime on EffectivePeriod

### DIFF
--- a/src/main/java/org/projectbarbel/histo/BarbelHistoContext.java
+++ b/src/main/java/org/projectbarbel/histo/BarbelHistoContext.java
@@ -60,6 +60,7 @@ public interface BarbelHistoContext {
         return BarbelHistoBuilder.SYSTEMACTIVITY;
     }
 
+    @Deprecated
     static LocalDate getInfiniteDate() {
         return LocalDate.MAX;
     }

--- a/src/main/java/org/projectbarbel/histo/BarbelHistoCore.java
+++ b/src/main/java/org/projectbarbel/histo/BarbelHistoCore.java
@@ -1,7 +1,6 @@
 package org.projectbarbel.histo;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
@@ -71,7 +70,7 @@ public final class BarbelHistoCore<T> implements BarbelHisto<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public BitemporalUpdate<T> save(T newVersion, LocalDate from, LocalDate until) {
+    public BitemporalUpdate<T> save(T newVersion, ZonedDateTime from, ZonedDateTime until) {
         Validate.noNullElements(Arrays.asList(newVersion, from, until), NOTNULL);
         Validate.notNull(newVersion, NOTNULL);
         Validate.isTrue(from.isBefore(until), "from date must be before until date");
@@ -232,11 +231,11 @@ public final class BarbelHistoCore<T> implements BarbelHisto<T> {
     }
 
     @Override
-    public DocumentJournal timeshift(Object id, LocalDateTime time) {
+    public DocumentJournal timeshift(Object id, ZonedDateTime time) {
         Validate.isTrue(id != null && time != null, NOTNULL);
         Validate.isTrue(
-                time.isBefore(BarbelHistoContext.getBarbelClock().now().toLocalDateTime())
-                        || time.equals(BarbelHistoContext.getBarbelClock().now().toLocalDateTime()),
+                time.isBefore(BarbelHistoContext.getBarbelClock().now())
+                        || time.equals(BarbelHistoContext.getBarbelClock().now()),
                 "timeshift only allowed in the past");
         List<T> result = retrieve(BarbelQueries.journalAt(id, time));
         IndexedCollection<Bitemporal> copiedAndActivatedBitemporals = result.stream()

--- a/src/main/java/org/projectbarbel/histo/DocumentJournal.java
+++ b/src/main/java/org/projectbarbel/histo/DocumentJournal.java
@@ -4,7 +4,7 @@ import static com.googlecode.cqengine.query.QueryFactory.ascending;
 import static com.googlecode.cqengine.query.QueryFactory.orderBy;
 import static com.googlecode.cqengine.query.QueryFactory.queryOptions;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -328,25 +328,25 @@ public final class DocumentJournal {
         }
 
         @SuppressWarnings("unchecked")
-        public <O> Optional<O> effectiveAt(LocalDate day) {
+        public <O> Optional<O> effectiveAt(ZonedDateTime time) {
             return journal.journal
-                    .retrieve(BarbelQueries.effectiveAt(journal.id, day),
+                    .retrieve(BarbelQueries.effectiveAt(journal.id, time),
                             queryOptions(orderBy(ascending(BarbelQueries.EFFECTIVE_FROM))))
                     .stream().map(d -> journal.processingState.expose(journal.context, (Bitemporal) d)).findFirst()
                     .flatMap(o -> Optional.of((Bitemporal) o));
         }
 
         /**
-         * The active versions after the given date. If due date is set to today, the
+         * The active versions after the given time. If due time is set to now, the
          * query returns all the future versions that will become effective.
          * 
-         * @param day the due date
+         * @param time the due time
          * @return the active versions
          */
         @SuppressWarnings("unchecked")
-        public <O> List<O> effectiveAfter(LocalDate day) {
+        public <O> List<O> effectiveAfter(ZonedDateTime time) {
             return (List<O>) journal.journal
-                    .retrieve(BarbelQueries.effectiveAfter(journal.id, day),
+                    .retrieve(BarbelQueries.effectiveAfter(journal.id, time),
                             queryOptions(orderBy(ascending(BarbelQueries.EFFECTIVE_FROM))))
                     .stream().map(d -> journal.processingState.expose(journal.context, (Bitemporal) d))
                     .collect(Collectors.toList());

--- a/src/main/java/org/projectbarbel/histo/functions/EmbeddingJournalUpdateStrategy.java
+++ b/src/main/java/org/projectbarbel/histo/functions/EmbeddingJournalUpdateStrategy.java
@@ -1,6 +1,6 @@
 package org.projectbarbel.histo.functions;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,9 +43,9 @@ public class EmbeddingJournalUpdateStrategy implements BiConsumer<DocumentJourna
         Validate.isTrue(journal.getId().equals(update.getBitemporalStamp().getDocumentId()),
                 "update and journal must have same document id");
         Validate.isTrue(update.getBitemporalStamp().isActive(), "only active bitemporals are allowed here");
-        LocalDate rightBound = update.getBitemporalStamp().getEffectiveTime().until().equals(LocalDate.MAX)
-                ? LocalDate.MAX
-                : update.getBitemporalStamp().getEffectiveTime().until().minusDays(1);
+        ZonedDateTime rightBound = update.getBitemporalStamp().getEffectiveTime().isInfinite()
+                ? EffectivePeriod.INFINITE
+                : update.getBitemporalStamp().getEffectiveTime().until().minusNanos(1000000); //we substract one millisecond
         Optional<Bitemporal> interruptedLeftVersion = journal.read()
                 .effectiveAt(update.getBitemporalStamp().getEffectiveTime().from());
         Optional<Bitemporal> interruptedRightVersion = journal.read().effectiveAt(rightBound);

--- a/src/main/java/org/projectbarbel/histo/model/BitemporalStamp.java
+++ b/src/main/java/org/projectbarbel/histo/model/BitemporalStamp.java
@@ -1,6 +1,5 @@
 package org.projectbarbel.histo.model;
 
-import java.time.LocalDate;
 import java.util.Objects;
 
 import org.projectbarbel.histo.BarbelHistoContext;
@@ -37,7 +36,7 @@ public final class BitemporalStamp {
         return builder().withActivity(BarbelHistoContext.getDefaultActivity())
                 .withDocumentId((String) BarbelHistoContext.getDefaultDocumentIDGenerator().get())
                 .withVersionId(BarbelHistoContext.getDefaultVersionIDGenerator().get())
-                .withEffectiveTime(EffectivePeriod.of(BarbelHistoContext.getBarbelClock().today(), LocalDate.MAX))
+                .withEffectiveTime(EffectivePeriod.nowToInfinite())
                 .withRecordTime(RecordPeriod.builder().build()).build();
     }
 
@@ -45,7 +44,7 @@ public final class BitemporalStamp {
         return builder().withActivity(BarbelHistoContext.getDefaultActivity())
                 .withDocumentId(id)
                 .withVersionId(BarbelHistoContext.getDefaultVersionIDGenerator().get())
-                .withEffectiveTime(EffectivePeriod.of(BarbelHistoContext.getBarbelClock().today(), LocalDate.MAX))
+                .withEffectiveTime(EffectivePeriod.nowToInfinite())
                 .withRecordTime(RecordPeriod.builder().build()).build();
     }
     

--- a/src/main/java/org/projectbarbel/histo/model/EffectivePeriod.java
+++ b/src/main/java/org/projectbarbel/histo/model/EffectivePeriod.java
@@ -1,6 +1,8 @@
 package org.projectbarbel.histo.model;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 import org.projectbarbel.histo.BarbelHistoContext;
@@ -12,34 +14,35 @@ import org.projectbarbel.histo.BarbelHistoContext;
  *
  */
 public final class EffectivePeriod {
-    
-    public static final LocalDate INFINITE = LocalDate.of(2199, 12, 31);
-    
-    private final LocalDate until;
-    private final LocalDate from;
 
-    private EffectivePeriod(LocalDate from, LocalDate until) {
+    public static final ZonedDateTime INFINITE = ZonedDateTime.of(LocalDateTime.of(2199, 12, 31, 23, 59),
+            ZoneId.of("Z"));
+
+    private final ZonedDateTime until;
+    private final ZonedDateTime from;
+
+    private EffectivePeriod(ZonedDateTime from, ZonedDateTime until) {
         this.from = Objects.requireNonNull(from);
         this.until = Objects.requireNonNull(until);
     }
 
-    public static EffectivePeriod of(LocalDate from, LocalDate until) {
+    public static EffectivePeriod of(ZonedDateTime from, ZonedDateTime until) {
         return new EffectivePeriod(from, until);
     }
 
     public static EffectivePeriod nowToInfinite() {
-    	return new EffectivePeriod(BarbelHistoContext.getBarbelClock().now().toLocalDate(), LocalDate.MAX);
+    	return new EffectivePeriod(BarbelHistoContext.getBarbelClock().now(), INFINITE);
     }
     
     public boolean isInfinite() {
-        return until.equals(BarbelHistoContext.getInfiniteDate());
+        return until.equals(INFINITE);
     }
 
-    public LocalDate from() {
+    public ZonedDateTime from() {
         return from;
     }
 
-    public LocalDate until() {
+    public ZonedDateTime until() {
         return until;
     }
 

--- a/src/main/java/org/projectbarbel/histo/model/Systemclock.java
+++ b/src/main/java/org/projectbarbel/histo/model/Systemclock.java
@@ -1,7 +1,6 @@
 package org.projectbarbel.histo.model;
 
 import java.time.Clock;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -25,12 +24,8 @@ public class Systemclock {
         return ZonedDateTime.now(clock);
     }
 
-    public LocalDate today() {
-        return ZonedDateTime.now(clock).toLocalDate();
-    }
-
-    public Systemclock useFixedClockAt(LocalDateTime date) {
-        clock = Clock.fixed(date.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+    public Systemclock useFixedClockAt(ZonedDateTime time) {
+        clock = Clock.fixed(time.toInstant(),time.getZone());
         return this;
     }
 

--- a/src/test/java/org/projectbarbel/histo/BarbelHistoCore_CQPersistence_Test.java
+++ b/src/test/java/org/projectbarbel/histo/BarbelHistoCore_CQPersistence_Test.java
@@ -7,13 +7,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.LocalDate;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.projectbarbel.histo.model.BarbelProxy;
 import org.projectbarbel.histo.model.Bitemporal;
+import org.projectbarbel.histo.model.EffectivePeriod;
 import org.projectbarbel.histo.pojos.ComplexFieldsPrivatePojoPartialContructor;
 import org.projectbarbel.histo.pojos.ComplexFieldsPrivatePojoPartialContructorWithComplexType;
 import org.projectbarbel.histo.pojos.NoPrimitivePrivatePojoPartialContructor;
@@ -88,12 +88,12 @@ public class BarbelHistoCore_CQPersistence_Test {
                 .withBackboneSupplier(() -> new ConcurrentIndexedCollection<PrimitivePrivatePojo>(
                         DiskPersistence.onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO, new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         core = BarbelHistoBuilder.barbel()
                 .withBackboneSupplier(() -> new ConcurrentIndexedCollection<PrimitivePrivatePojo>(
                         DiskPersistence.onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO, new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX);
+        core.save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(1), EffectivePeriod.INFINITE);
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal record = (Bitemporal) core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         assertNotNull(record.getBitemporalStamp().getDocumentId());
@@ -108,15 +108,15 @@ public class BarbelHistoCore_CQPersistence_Test {
                 .withBackboneSupplier(() -> new ConcurrentIndexedCollection<PrimitivePrivatePojo>(
                         DiskPersistence.onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO, new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         core = BarbelHistoBuilder.barbel()
                 .withBackboneSupplier(() -> new ConcurrentIndexedCollection<PrimitivePrivatePojo>(
                         DiskPersistence.onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO, new File(FILENAME))))
                 .build();
         pojo.someDouble = 123d;
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX); // save changed double to persistence
+        core.save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(1), EffectivePeriod.INFINITE); // save changed double to persistence
         BarbelProxy effectiveIn2Days = (BarbelProxy) core
-                .retrieveOne(BarbelQueries.effectiveAt(pojo.id, LocalDate.now().plusDays(2)));
+                .retrieveOne(BarbelQueries.effectiveAt(pojo.id, BarbelHistoContext.getBarbelClock().now().plusDays(2)));
         assertEquals(123d, ((PrimitivePrivatePojo) effectiveIn2Days.getTarget()).someDouble);
         // reopen to check whether change was made persistent
         core = BarbelHistoBuilder.barbel()
@@ -124,7 +124,7 @@ public class BarbelHistoCore_CQPersistence_Test {
                         DiskPersistence.onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO, new File(FILENAME))))
                 .build();
         effectiveIn2Days = (BarbelProxy) core
-                .retrieveOne(BarbelQueries.effectiveAt(pojo.id, LocalDate.now().plusDays(2)));
+                .retrieveOne(BarbelQueries.effectiveAt(pojo.id, BarbelHistoContext.getBarbelClock().now().plusDays(2)));
         assertEquals(123d, ((PrimitivePrivatePojo) effectiveIn2Days.getTarget()).someDouble);
     }
 
@@ -136,14 +136,14 @@ public class BarbelHistoCore_CQPersistence_Test {
                         () -> new ConcurrentIndexedCollection<PrimitivePrivatePojoPartialContructor>(DiskPersistence
                                 .onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO_PARTIAL, new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         core = BarbelHistoBuilder.barbel()
                 .withBackboneSupplier(
                         () -> new ConcurrentIndexedCollection<PrimitivePrivatePojoPartialContructor>(DiskPersistence
                                 .onPrimaryKeyInFile(VERSION_ID_PK_PRIMITIVE_PRIVATE_POJO_PARTIAL, new File(FILENAME))))
                 .build();
         PrimitivePrivatePojoPartialContructor saved = (PrimitivePrivatePojoPartialContructor) core
-                .save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX).getUpdateRequest();
+                .save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(1), EffectivePeriod.INFINITE).getUpdateRequest();
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal record = (Bitemporal) core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         assertNotNull(record.getBitemporalStamp().getDocumentId());
@@ -159,13 +159,13 @@ public class BarbelHistoCore_CQPersistence_Test {
                 () -> new ConcurrentIndexedCollection<NoPrimitivePrivatePojoPartialContructor>(DiskPersistence
                         .onPrimaryKeyInFile(VERSION_ID_PK_NO_PRIMITIVE_PRIVATE_POJO_PARTIAL, new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         core = BarbelHistoBuilder.barbel().withBackboneSupplier(
                 () -> new ConcurrentIndexedCollection<NoPrimitivePrivatePojoPartialContructor>(DiskPersistence
                         .onPrimaryKeyInFile(VERSION_ID_PK_NO_PRIMITIVE_PRIVATE_POJO_PARTIAL, new File(FILENAME))))
                 .build();
         NoPrimitivePrivatePojoPartialContructor saved = (NoPrimitivePrivatePojoPartialContructor) core
-                .save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX).getUpdateRequest();
+                .save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(1), EffectivePeriod.INFINITE).getUpdateRequest();
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal record = (Bitemporal) core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         assertNotNull(record.getBitemporalStamp().getDocumentId());
@@ -181,13 +181,13 @@ public class BarbelHistoCore_CQPersistence_Test {
                 () -> new ConcurrentIndexedCollection<ComplexFieldsPrivatePojoPartialContructor>(DiskPersistence
                         .onPrimaryKeyInFile(ComplexFieldsPrivatePojoPartialContructor_Field, new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         core = BarbelHistoBuilder.barbel().withBackboneSupplier(
                 () -> new ConcurrentIndexedCollection<ComplexFieldsPrivatePojoPartialContructor>(DiskPersistence
                         .onPrimaryKeyInFile(ComplexFieldsPrivatePojoPartialContructor_Field, new File(FILENAME))))
                 .build();
         ComplexFieldsPrivatePojoPartialContructor saved = (ComplexFieldsPrivatePojoPartialContructor) core
-                .save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX).getUpdateRequest();
+                .save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(1),EffectivePeriod.INFINITE).getUpdateRequest();
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal record = (Bitemporal) core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         assertNotNull(record.getBitemporalStamp().getDocumentId());
@@ -206,14 +206,14 @@ public class BarbelHistoCore_CQPersistence_Test {
                                         ComplexFieldsPrivatePojoPartialContructorWithComplexType_Field,
                                         new File(FILENAME))))
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         core = BarbelHistoBuilder.barbel().withBackboneSupplier(
                 () -> new ConcurrentIndexedCollection<ComplexFieldsPrivatePojoPartialContructorWithComplexType>(
                         DiskPersistence.onPrimaryKeyInFile(
                                 ComplexFieldsPrivatePojoPartialContructorWithComplexType_Field, new File(FILENAME))))
                 .build();
         ComplexFieldsPrivatePojoPartialContructorWithComplexType saved = (ComplexFieldsPrivatePojoPartialContructorWithComplexType) core
-                .save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX).getUpdateRequest();
+                .save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(1)).getUpdateRequest();
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal record = (Bitemporal) core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         assertNotNull(record.getBitemporalStamp().getDocumentId());

--- a/src/test/java/org/projectbarbel/histo/BarbelHistoCore_DZone_Article1_Test.java
+++ b/src/test/java/org/projectbarbel/histo/BarbelHistoCore_DZone_Article1_Test.java
@@ -2,12 +2,13 @@ package org.projectbarbel.histo;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.projectbarbel.histo.model.EffectivePeriod;
 
 public class BarbelHistoCore_DZone_Article1_Test {
 
@@ -21,11 +22,11 @@ public class BarbelHistoCore_DZone_Article1_Test {
 
 		BarbelHisto<Client> barbel = BarbelHistoBuilder.barbel().build();
 		Client client = new Client("1234", "Martin", "Smith");
-		barbel.save(client, LocalDate.now(), LocalDate.MAX);
+		barbel.save(client);
 
 		Client effectiveNow = barbel.retrieveOne(BarbelQueries.effectiveNow("1234"));
 		effectiveNow.getAdresses().add(new Adress("Barbel Street 10", "Houston"));
-		barbel.save(effectiveNow, LocalDate.of(2019, 3, 1), LocalDate.MAX);
+		barbel.save(effectiveNow, ZonedDateTime.parse("2019-03-01T00:00:00Z"), EffectivePeriod.INFINITE);
 
 		System.out.println(barbel.prettyPrintJournal("1234"));
 

--- a/src/test/java/org/projectbarbel/histo/BarbelModeTest.java
+++ b/src/test/java/org/projectbarbel/histo/BarbelModeTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -72,16 +72,16 @@ public class BarbelModeTest {
 				BarbelMode.POJO
 						.managedBitemporalToPersistenceObjects("some",
 								BarbelTestHelper.generateJournalOfManagedDefaultPojos(BarbelHistoBuilder.barbel(),"some",
-										Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1))))
+										Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-03-01T00:00:00Z"))))
 						.size() == 2);
 	}
 
 	@Test
 	public void testManagedBitemporalToCustomPersistenceObjectsTwoJournals() throws Exception {
 		IndexedCollection<Object> bitemporals = BarbelTestHelper.generateJournalOfManagedDefaultPojos(BarbelHistoBuilder.barbel(),"some",
-				Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1)));
+				Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-03-01T00:00:00Z")));
 		bitemporals.addAll(BarbelTestHelper.generateJournalOfManagedDefaultPojos(BarbelHistoBuilder.barbel(),"other",
-				Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1))));
+				Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-03-01T00:00:00Z"))));
 		assertTrue(BarbelMode.POJO.managedBitemporalToPersistenceObjects("some", bitemporals).size() == 2);
 	}
 
@@ -175,7 +175,7 @@ public class BarbelModeTest {
         Bitemporal doc = BarbelMode.POJO.snapshotMaiden(BarbelHistoBuilder.barbel(), pojo, stamp);
         assertEquals(new BitemporalVersion(stamp, pojo), BarbelMode.POJO.managedBitemporalToPersistenceObject(doc));
     }
-    
+
 	@Test
 	public void testSnapshotManagedBitemporal_BitemporalMode() throws Exception {
 		Bitemporal managed = BarbelMode.BITEMPORAL.snapshotMaiden(BarbelHistoBuilder.barbel(),
@@ -215,19 +215,19 @@ public class BarbelModeTest {
 				BarbelMode.BITEMPORAL
 						.managedBitemporalToPersistenceObjects("some",
 								BarbelTestHelper.generateJournalOfManagedDefaultPojos(BarbelHistoBuilder.barbel(), "some",
-										Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1))))
+										Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-03-01T00:00:00Z"))))
 						.size() == 2);
 	}
 
 	@Test
 	public void testManagedBitemporalToCustomPersistenceObjectsTwoJournals_BitemporalMode() throws Exception {
 		IndexedCollection<Object> bitemporals = BarbelTestHelper.generateJournalOfDefaultDocuments("some",
-				Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1)));
+				Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-03-01T00:00:00Z")));
 		bitemporals.addAll(BarbelTestHelper.generateJournalOfDefaultDocuments("other",
-				Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 3, 1))));
+				Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-03-01T00:00:00Z"))));
 		assertTrue(BarbelMode.BITEMPORAL.managedBitemporalToPersistenceObjects("some", bitemporals).size() == 2);
 	}
-	
+
 	@Test
 	public void testCustomPersistenceObjectsToManagedBitemporals_BitemporalMode() throws Exception {
 		assertTrue(BarbelMode.BITEMPORAL.persistenceObjectsToManagedBitemporals(BarbelHistoBuilder.barbel(),

--- a/src/test/java/org/projectbarbel/histo/BarbelQueriesTest.java
+++ b/src/test/java/org/projectbarbel/histo/BarbelQueriesTest.java
@@ -3,8 +3,6 @@ package org.projectbarbel.histo;
 import static com.googlecode.cqengine.query.QueryFactory.and;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
@@ -18,10 +16,10 @@ public class BarbelQueriesTest {
         assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.all("some")));
         assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.allActive("some")));
         assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.allInactive("some")));
-        assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.effectiveAfter("some", LocalDate.now())));
+        assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.effectiveAfter("some", BarbelHistoContext.getBarbelClock().now())));
         assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.effectiveBetween("some", EffectivePeriod.nowToInfinite())));
-        assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.effectiveAt("some", LocalDate.now())));
-        assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.journalAt("some", LocalDateTime.now())));
+        assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.effectiveAt("some", BarbelHistoContext.getBarbelClock().now())));
+        assertEquals("some",BarbelQueries.returnIDForQuery(BarbelQueries.journalAt("some", BarbelHistoContext.getBarbelClock().now())));
     }
 
     @Test

--- a/src/test/java/org/projectbarbel/histo/DocumentJournalTest.java
+++ b/src/test/java/org/projectbarbel/histo/DocumentJournalTest.java
@@ -5,8 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ public class DocumentJournalTest {
 	public void testCreate_withList() {
 		DocumentJournal journal = DocumentJournal.create(ProcessingState.INTERNAL, BarbelHistoBuilder.barbel(),
 				BarbelTestHelper.generateJournalOfDefaultDocuments("#12345",
-						Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 4, 1))),
+						Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-04-01T00:00:00Z"))),
 				"#12345");
 		assertEquals(2, journal.size());
 	}
@@ -56,7 +57,7 @@ public class DocumentJournalTest {
 	@Test
 	public void testUpdate() throws Exception {
 		IndexedCollection<Object> coll = new ConcurrentIndexedCollection<Object>();
-		BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 2, 1, 8, 0));
+		BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 2, 1, 8, 0).atZone(ZoneId.of("Z")));
 		DefaultDocument doc = DefaultDocument.builder().withData("some data")
 				.withBitemporalStamp(BitemporalStamp.createActive()).build();
 		coll.add(doc);
@@ -73,10 +74,10 @@ public class DocumentJournalTest {
 		DocumentJournal journal = DocumentJournal.create(ProcessingState.INTERNAL,
 				BarbelHistoBuilder.barbel().withMode(BarbelMode.BITEMPORAL),
 				BarbelTestHelper.generateJournalOfDefaultDocuments("#12345",
-						Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 4, 1))),
+						Arrays.asList(ZonedDateTime.parse("2019-01-01T00:00:00Z"), ZonedDateTime.parse("2019-04-01T00:00:00Z"))),
 				"#12345");
 		assertEquals(((Bitemporal) journal.list().get(0)).getBitemporalStamp().getEffectiveTime().from(),
-				LocalDate.of(2019, 1, 1));
+				ZonedDateTime.parse("2019-01-01T00:00:00Z"));
 	}
 
 }

--- a/src/test/java/org/projectbarbel/histo/functions/BarbelQueries_effectiveAfterTest.java
+++ b/src/test/java/org/projectbarbel/histo/functions/BarbelQueries_effectiveAfterTest.java
@@ -6,8 +6,9 @@ import static com.googlecode.cqengine.query.QueryFactory.queryOptions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterAll;
@@ -28,8 +29,9 @@ public class BarbelQueries_effectiveAfterTest {
     @BeforeEach
     public void setUp() {
         journal = BarbelTestHelper.generateJournalOfDefaultDocuments("docid1",
-                Arrays.asList(LocalDate.of(2010, 12, 1), LocalDate.of(2017, 12, 1), LocalDate.of(2020, 1, 1)));
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 1, 30, 8, 0, 0));
+                Arrays.asList(
+                        ZonedDateTime.parse("2010-12-01T00:00:00Z"), ZonedDateTime.parse("2017-12-01T00:00:00Z"), ZonedDateTime.parse("2020-01-01T00:00:00Z")));
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 1, 30, 8, 0, 0).atZone(ZoneId.of("Z")));
     }
     
     @AfterAll
@@ -40,46 +42,46 @@ public class BarbelQueries_effectiveAfterTest {
     @Test
     public void testApply_threeRecord_onePeriodAfterCurrent() throws Exception {
         ResultSet<DefaultDocument> documents = journal
-                .retrieve(BarbelQueries.effectiveAfter("docid1", BarbelHistoContext.getBarbelClock().now().toLocalDate()));
+                .retrieve(BarbelQueries.effectiveAfter("docid1", BarbelHistoContext.getBarbelClock().now()));
         assertTrue(documents.size() == 1);
         assertEquals(documents.iterator().next().getBitemporalStamp().getEffectiveTime().from(),
-                LocalDate.of(2020, 1, 1));
+                ZonedDateTime.parse("2020-01-01T00:00:00Z"));
     }
 
     @Test
     public void testApply_threeRecord_allAfter_DueDateOnBeginning() throws Exception {
         ResultSet<DefaultDocument> documents = journal.retrieve(
-                BarbelQueries.effectiveAfter("docid1", LocalDate.of(2010, 12, 1)),
+                BarbelQueries.effectiveAfter("docid1", ZonedDateTime.parse("2010-12-01T00:00:00Z")),
                 queryOptions(orderBy(ascending(BarbelQueries.EFFECTIVE_FROM))));
         assertTrue(documents.size() == 3);
-        assertEquals(LocalDate.of(2010, 12, 1),
+        assertEquals(ZonedDateTime.parse("2010-12-01T00:00:00Z"),
                 documents.iterator().next().getBitemporalStamp().getEffectiveTime().from());
     }
 
     @Test
     public void testApply_threeRecord_allAfter_DueDateBefore() throws Exception {
         ResultSet<DefaultDocument> documents = journal.retrieve(
-                BarbelQueries.effectiveAfter("docid1", LocalDate.of(2010, 11, 1)),
+                BarbelQueries.effectiveAfter("docid1", ZonedDateTime.parse("2010-11-01T00:00:00Z")),
                 queryOptions(orderBy(ascending(BarbelQueries.EFFECTIVE_FROM))));
         assertTrue(documents.size() == 3);
-        assertEquals(LocalDate.of(2010, 12, 1),
+        assertEquals(ZonedDateTime.parse("2010-12-01T00:00:00Z"),
                 documents.iterator().next().getBitemporalStamp().getEffectiveTime().from());
     }
 
     @Test
     public void testApply_threeRecord_twoAfter() throws Exception {
         ResultSet<DefaultDocument> documents = journal.retrieve(
-                BarbelQueries.effectiveAfter("docid1", LocalDate.of(2011, 12, 1)),
+                BarbelQueries.effectiveAfter("docid1", ZonedDateTime.parse("2011-12-01T00:00:00Z")),
                 queryOptions(orderBy(ascending(BarbelQueries.EFFECTIVE_FROM))));
         assertTrue(documents.size() == 2);
-        assertEquals(LocalDate.of(2017, 12, 1),
+        assertEquals(ZonedDateTime.parse("2017-12-01T00:00:00Z"),
                 documents.iterator().next().getBitemporalStamp().getEffectiveTime().from());
     }
 
     @Test
     public void testApply_threeRecord_oneAfter() throws Exception {
         ResultSet<DefaultDocument> documents = journal.retrieve(
-                BarbelQueries.effectiveAfter("docid1", LocalDate.of(2021, 12, 1)),
+                BarbelQueries.effectiveAfter("docid1", ZonedDateTime.parse("2021-12-01T00:00:00Z")),
                 queryOptions(orderBy(ascending(BarbelQueries.EFFECTIVE_FROM))));
         assertTrue(documents.size() == 0);
     }

--- a/src/test/java/org/projectbarbel/histo/functions/BarbelQueries_effectiveAtTest.java
+++ b/src/test/java/org/projectbarbel/histo/functions/BarbelQueries_effectiveAtTest.java
@@ -4,8 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterAll;
@@ -26,8 +27,9 @@ public class BarbelQueries_effectiveAtTest {
     @BeforeEach
     public void setUp() {
         journal = BarbelTestHelper.generateJournalOfDefaultDocuments("docid1",
-                Arrays.asList(LocalDate.of(2010, 12, 1), LocalDate.of(2017, 12, 1), LocalDate.of(2020, 1, 1)));
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 1, 30, 8, 0, 0));
+                Arrays.asList(
+                        ZonedDateTime.parse("2010-12-01T00:00:00Z"), ZonedDateTime.parse("2017-12-01T00:00:00Z"), ZonedDateTime.parse("2020-01-01T00:00:00Z")));
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 1, 30, 8, 0, 0).atZone(ZoneId.of("Z")));
     }
 
     @AfterAll
@@ -37,29 +39,29 @@ public class BarbelQueries_effectiveAtTest {
 
     @Test
     public void testApply() throws Exception {
-        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", BarbelHistoContext.getBarbelClock().now().toLocalDate()));
+        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", BarbelHistoContext.getBarbelClock().now()));
         assertTrue(document.iterator().hasNext());
-        assertEquals(document.iterator().next().getBitemporalStamp().getEffectiveTime().from(), LocalDate.of(2017, 12, 1));
+        assertEquals(document.iterator().next().getBitemporalStamp().getEffectiveTime().from(), ZonedDateTime.parse("2017-12-01T00:00:00Z"));
     }
 
     @Test
     public void testApply_laterDoc() throws Exception {
-        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", LocalDate.of(2021, 12, 1)));
+        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", ZonedDateTime.parse("2021-12-01T00:00:00Z")));
         assertTrue(document.iterator().hasNext());
-        assertEquals(document.iterator().next().getBitemporalStamp().getEffectiveTime().from(), LocalDate.of(2020, 1, 1));
+        assertEquals(document.iterator().next().getBitemporalStamp().getEffectiveTime().from(), ZonedDateTime.parse("2020-01-01T00:00:00Z"));
     }
 
     @Test
     public void testApply_nonEffective() throws Exception {
-        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", LocalDate.of(2000, 12, 1)));
+        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", ZonedDateTime.parse("2000-12-01T00:00:00Z")));
         assertFalse(document.iterator().hasNext());
     }
     
     @Test
     public void testApply_earlierDoc() throws Exception {
-        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", LocalDate.of(2012, 12, 1)));
+        ResultSet<DefaultDocument> document = journal.retrieve(BarbelQueries.effectiveAt("docid1", ZonedDateTime.parse("2012-12-01T00:00:00Z")));
         assertTrue(document.iterator().hasNext());
-        assertEquals(document.iterator().next().getBitemporalStamp().getEffectiveTime().from(), LocalDate.of(2010, 12, 1));
+        assertEquals(document.iterator().next().getBitemporalStamp().getEffectiveTime().from(), ZonedDateTime.parse("2010-12-01T00:00:00Z"));
     }
 
 }

--- a/src/test/java/org/projectbarbel/histo/functions/BarbelQueries_effectiveBetween.java
+++ b/src/test/java/org/projectbarbel/histo/functions/BarbelQueries_effectiveBetween.java
@@ -3,8 +3,9 @@ package org.projectbarbel.histo.functions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterAll;
@@ -26,8 +27,8 @@ public class BarbelQueries_effectiveBetween {
     @BeforeEach
     public void setUp() {
         journal = BarbelTestHelper.generateJournalOfDefaultDocuments("docid1",
-                Arrays.asList(LocalDate.of(2010, 12, 1), LocalDate.of(2017, 12, 1), LocalDate.of(2020, 1, 1)));
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 1, 30, 8, 0, 0));
+                Arrays.asList(ZonedDateTime.parse("2010-12-01T00:00:00Z"), ZonedDateTime.parse("2017-12-01T00:00:00Z"), ZonedDateTime.parse("2020-01-01T00:00:00Z")));
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.of(2019, 1, 30, 8, 0, 0).atZone(ZoneId.of("Z")));
     }
 
     @AfterAll
@@ -38,16 +39,16 @@ public class BarbelQueries_effectiveBetween {
     @Test
     public void testApply_threeRecord_onePeriodBetween() throws Exception {
         ResultSet<DefaultDocument> documents = journal.retrieve(BarbelQueries.effectiveBetween("docid1",
-                EffectivePeriod.of(LocalDate.of(2010, 12, 2), LocalDate.of(2020, 1, 2))));
+                EffectivePeriod.of(ZonedDateTime.parse("2010-12-02T00:00:00Z"), ZonedDateTime.parse("2020-01-02T00:00:00Z"))));
         assertTrue(documents.size() == 1);
         assertEquals(documents.iterator().next().getBitemporalStamp().getEffectiveTime().from(),
-                LocalDate.of(2017, 12, 1));
+                ZonedDateTime.parse("2017-12-01T00:00:00Z"));
     }
 
     @Test
     public void testApply_threeRecord_allBetween() throws Exception {
         ResultSet<DefaultDocument> documents = journal.retrieve(BarbelQueries.effectiveBetween("docid1",
-                EffectivePeriod.of(LocalDate.of(2010, 11, 1), BarbelHistoContext.getInfiniteDate())));
+                EffectivePeriod.of(ZonedDateTime.parse("2010-11-01T00:00:00Z"), EffectivePeriod.INFINITE)));
         assertTrue(documents.size() == 3);
     }
 

--- a/src/test/java/org/projectbarbel/histo/model/BitemporalStampTest.java
+++ b/src/test/java/org/projectbarbel/histo/model/BitemporalStampTest.java
@@ -2,22 +2,20 @@ package org.projectbarbel.histo.model;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Test;
 
 public class BitemporalStampTest {
 
     @Test
     public void testCopy() throws Exception {
-        BitemporalStamp bs = BitemporalStamp.of("test", "test", EffectivePeriod.of(LocalDate.now(), LocalDate.MAX),
+        BitemporalStamp bs = BitemporalStamp.of("test", "test", EffectivePeriod.nowToInfinite(),
                 RecordPeriod.builder().build());
         assertNotNull(bs);
     }
 
     @Test
     public void testCopy_versionIdSet() throws Exception {
-        BitemporalStamp bs = BitemporalStamp.of("test", "test", EffectivePeriod.of(LocalDate.now(), LocalDate.MAX),
+        BitemporalStamp bs = BitemporalStamp.of("test", "test", EffectivePeriod.nowToInfinite(),
                 RecordPeriod.builder().build());
         assertNotNull(bs.getVersionId());
     }

--- a/src/test/java/org/projectbarbel/histo/model/RecordPeriodTest.java
+++ b/src/test/java/org/projectbarbel/histo/model/RecordPeriodTest.java
@@ -20,10 +20,10 @@ public class RecordPeriodTest {
 
 	@Test
 	public void testCreateActive() throws Exception {
-		LocalDateTime now = LocalDateTime.now();
+		ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of("Z"));
 		BarbelHistoContext.getBarbelClock().useFixedClockAt(now);
 		RecordPeriod period = RecordPeriod.createActive(BarbelHistoBuilder.barbel());
-		assertEquals(period.getCreatedAt(), ZonedDateTime.of(now, ZoneId.systemDefault()));
+		assertEquals(period.getCreatedAt(), now);
 		assertEquals(BarbelHistoBuilder.SYSTEM, period.getCreatedBy());
 		assertEquals(RecordPeriod.NOT_INACTIVATED, period.getInactivatedAt());
 		assertEquals(RecordPeriod.NOBODY, period.getInactivatedBy());
@@ -44,7 +44,7 @@ public class RecordPeriodTest {
 
 	@Test
 	public void testEquals() throws Exception {
-		LocalDateTime now = LocalDateTime.now();
+		ZonedDateTime now = LocalDateTime.now().atZone(ZoneId.of("Z"));
 		BarbelHistoContext.getBarbelClock().useFixedClockAt(now);
 		RecordPeriod period1 = RecordPeriod.createActive(BarbelHistoBuilder.barbel());
 		RecordPeriod period2 = RecordPeriod.createActive(BarbelHistoBuilder.barbel());

--- a/src/test/java/org/projectbarbel/histo/suite/listener/BarbelHistoCore_MultiUpdate_andQueryBitemporal_Listener_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/listener/BarbelHistoCore_MultiUpdate_andQueryBitemporal_Listener_SuiteTest.java
@@ -2,8 +2,6 @@ package org.projectbarbel.histo.suite.listener;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.projectbarbel.histo.BarbelHisto;
@@ -24,7 +22,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal_Listener_SuiteTest
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class)
                 .withMode(BarbelMode.BITEMPORAL).build();
         DefaultDocument pojo = new DefaultDocument("someOther", "some data");
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         assertEquals(1, ((BarbelHistoCore<DefaultDocument>) core).size());
     }
 

--- a/src/test/java/org/projectbarbel/histo/suite/listener/BarbelHistoCore_MultiUpdate_andQuery_Listener_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/listener/BarbelHistoCore_MultiUpdate_andQuery_Listener_SuiteTest.java
@@ -2,8 +2,6 @@ package org.projectbarbel.histo.suite.listener;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.projectbarbel.histo.BarbelHisto;
@@ -21,7 +19,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery_Listener_SuiteTest extends Bar
     public void addSomeMoreData() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
         DefaultPojo pojo = new DefaultPojo("someOther", "some data");
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         assertEquals(1, ((BarbelHistoCore<DefaultPojo>)core).size());
     }
 

--- a/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQuery.java
+++ b/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQuery.java
@@ -2,14 +2,14 @@ package org.projectbarbel.histo.suite.persistent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelQueries;
 import org.projectbarbel.histo.model.DefaultPojo;
@@ -29,9 +29,9 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
     void embeddedOverlap_Extrapolate() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
         DefaultPojo pojo = new DefaultPojo("someSome", "some data");
-        
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         // Now |---------------------------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(0, core.retrieve(BarbelQueries.allInactive("someSome")).size());
                 
@@ -39,7 +39,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //      1|---------------|10
         //     |-|---------------|---------------| 20
         pojo = new DefaultPojo("someSome", "changed");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(10));
+        core.save(pojo, now.plusDays(1), now.plusDays(10));
         assertEquals(4,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(1, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -48,7 +48,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
         pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(5,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(3, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -56,7 +56,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|-------------------------------| 20
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(6,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(4, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -64,7 +64,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|-------------------------------| 20
         //     |---------------------------------| 20
         //     |---------------------------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(7,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(6, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -72,7 +72,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |---------------------------------| 20
         //     |-----------------| 10
         //     |-----------------|---------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(10));
+        core.save(pojo, now, now.plusDays(10));
         assertEquals(9,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(7, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -80,7 +80,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-----------------|---------------| 20
         //     |--------------------------------------------------| 100
         //     |--------------------------------------------------| 100
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(100));
+        core.save(pojo, now, now.plusDays(100));
         assertEquals(10,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(9, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -88,7 +88,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |---------------------------------------------------| 100
         //     |-|-----------------------------------------------|-| 100
         //     |-|-----------------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(99));
+        core.save(pojo, now.plusDays(1), now.plusDays(99));
         assertEquals(13,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(10, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -96,7 +96,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|-----------------------------------------------|-| 100
         //       |--| 3
         //     |-|--|--------------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(3));
+        core.save(pojo, now.plusDays(1), now.plusDays(3));
         assertEquals(15,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(11, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -104,7 +104,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|--|--------------------------------------------|-| 100
         //         3|--|5
         //     |-|--|--|-----------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(3), LocalDate.now().plusDays(5));
+        core.save(pojo, now.plusDays(3), now.plusDays(5));
         assertEquals(17,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(12, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -112,7 +112,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|--|--|-----------------------------------------|-| 100
         //            5|--|7
         //     |-|--|--|--|--------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(5), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(5), now.plusDays(7));
         assertEquals(19,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(6, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(13, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -120,7 +120,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|--|--|--|--------------------------------------|-| 100
         //                |----------------------------------------| 100
         //     |-|--|--|--|----------------------------------------| 100
-        core.save(pojo, LocalDate.now().plusDays(7), LocalDate.now().plusDays(100));
+        core.save(pojo, now.plusDays(7), now.plusDays(100));
         assertEquals(20,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(15, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -128,7 +128,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-|--|--|--|----------------------------------------| 100
         //        |------|
         //     |-||------||----------------------------------------| 100
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(6));
+        core.save(pojo, now.plusDays(2), now.plusDays(6));
         assertEquals(23,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(18, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -136,7 +136,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
         //     |-||------||----------------------------------------| 100
         //        |-------|
         //     |-||-------|----------------------------------------| 100
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(2), now.plusDays(7));
         assertEquals(24,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(20, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -165,13 +165,13 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
     @Test
     void allOtherQueries_preFetch_effectiveAfter() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
-        assertEquals(2, core.retrieve(BarbelQueries.effectiveAfter("someSome", LocalDate.now().plusDays(2))).size());
+        assertEquals(2, core.retrieve(BarbelQueries.effectiveAfter("someSome", BarbelHistoContext.getBarbelClock().now().plusDays(2))).size());
     }
     @Order(7)
     @Test
     void allOtherQueries_preFetch_effectiveBetween() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
-        assertEquals(4, core.retrieve(BarbelQueries.effectiveBetween("someSome", EffectivePeriod.of(LocalDate.now(), LocalDate.MAX))).size());
+        assertEquals(4, core.retrieve(BarbelQueries.effectiveBetween("someSome", EffectivePeriod.nowToInfinite())).size());
     }
     @Order(8)
     @Test
@@ -184,7 +184,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery {
     @Test
     void allOtherQueries_preFetch_journalAt() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
-        assertEquals(4, core.retrieve(BarbelQueries.journalAt("someSome", LocalDateTime.now())).size());
+        assertEquals(4, core.retrieve(BarbelQueries.journalAt("someSome", BarbelHistoContext.getBarbelClock().now())).size());
     }
     @Order(10)
     @Test

--- a/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQueryBitemporal.java
+++ b/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQueryBitemporal.java
@@ -2,14 +2,18 @@ package org.projectbarbel.histo.suite.persistent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelMode;
 import org.projectbarbel.histo.BarbelQueries;
@@ -24,15 +28,25 @@ import com.googlecode.cqengine.query.QueryFactory;
 @BTNotStandAlone
 public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
 
+
+    @BeforeAll
+    public static void setFixedClock(){
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.now().atZone(ZoneId.of("Z")));
+    }
+
+    @AfterAll
+    public static void resetClock(){
+        BarbelHistoContext.getBarbelClock().useSystemDefaultZoneClock();
+    }
     // @formatter:off
     @Order(1)
     @Test
     void embeddedOverlap_Extrapolate() throws Exception {
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class).withMode(BarbelMode.BITEMPORAL).build();
         DefaultDocument pojo = new DefaultDocument("someSome", "some data");
-        
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         // Now |---------------------------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(0, core.retrieve(BarbelQueries.allInactive("someSome")).size());
                 
@@ -40,7 +54,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //      1|---------------|10
         //     |-|---------------|---------------| 20
         pojo = new DefaultDocument("someSome", "changed");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(10));
+        core.save(pojo, now.plusDays(1), now.plusDays(10));
         assertEquals(4,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(1, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -49,7 +63,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
         pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(5,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(3, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -57,7 +71,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|-------------------------------| 20
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(6,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(4, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -65,7 +79,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|-------------------------------| 20
         //     |---------------------------------| 20
         //     |---------------------------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(7,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(6, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -73,7 +87,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |---------------------------------| 20
         //     |-----------------| 10
         //     |-----------------|---------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(10));
+        core.save(pojo, now, now.plusDays(10));
         assertEquals(9,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(7, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -81,7 +95,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-----------------|---------------| 20
         //     |--------------------------------------------------| 100
         //     |--------------------------------------------------| 100
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(100));
+        core.save(pojo, now, now.plusDays(100));
         assertEquals(10,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(9, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -89,7 +103,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |---------------------------------------------------| 100
         //     |-|-----------------------------------------------|-| 100
         //     |-|-----------------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(99));
+        core.save(pojo, now.plusDays(1), now.plusDays(99));
         assertEquals(13,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(10, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -97,7 +111,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|-----------------------------------------------|-| 100
         //       |--| 3
         //     |-|--|--------------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(3));
+        core.save(pojo, now.plusDays(1), now.plusDays(3));
         assertEquals(15,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(11, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -105,7 +119,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|--|--------------------------------------------|-| 100
         //         3|--|5
         //     |-|--|--|-----------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(3), LocalDate.now().plusDays(5));
+        core.save(pojo, now.plusDays(3), now.plusDays(5));
         assertEquals(17,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(12, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -113,7 +127,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|--|--|-----------------------------------------|-| 100
         //            5|--|7
         //     |-|--|--|--|--------------------------------------|-| 100
-        core.save(pojo, LocalDate.now().plusDays(5), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(5), now.plusDays(7));
         assertEquals(19,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(6, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(13, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -121,7 +135,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|--|--|--|--------------------------------------|-| 100
         //                |----------------------------------------| 100
         //     |-|--|--|--|----------------------------------------| 100
-        core.save(pojo, LocalDate.now().plusDays(7), LocalDate.now().plusDays(100));
+        core.save(pojo, now.plusDays(7), now.plusDays(100));
         assertEquals(20,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(15, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -129,7 +143,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-|--|--|--|----------------------------------------| 100
         //        |------|
         //     |-||------||----------------------------------------| 100
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(6));
+        core.save(pojo, now.plusDays(2), now.plusDays(6));
         assertEquals(23,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(18, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -137,7 +151,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
         //     |-||------||----------------------------------------| 100
         //        |-------|
         //     |-||-------|----------------------------------------| 100
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(2), now.plusDays(7));
         assertEquals(24,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(20, core.retrieve(BarbelQueries.allInactive("someSome")).size());
@@ -166,13 +180,13 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
     @Test
     void allOtherQueries_preFetch_effectiveAfter() throws Exception {
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class).withMode(BarbelMode.BITEMPORAL).build();
-        assertEquals(2, core.retrieve(BarbelQueries.effectiveAfter("someSome", LocalDate.now().plusDays(2))).size());
+        assertEquals(2, core.retrieve(BarbelQueries.effectiveAfter("someSome", BarbelHistoContext.getBarbelClock().now().plusDays(2))).size());
     }
     @Order(7)
     @Test
     void allOtherQueries_preFetch_effectiveBetween() throws Exception {
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class).withMode(BarbelMode.BITEMPORAL).build();
-        assertEquals(4, core.retrieve(BarbelQueries.effectiveBetween("someSome", EffectivePeriod.of(LocalDate.now(), LocalDate.MAX))).size());
+        assertEquals(4, core.retrieve(BarbelQueries.effectiveBetween("someSome", EffectivePeriod.of(BarbelHistoContext.getBarbelClock().now(), EffectivePeriod.INFINITE))).size());
     }
     @Order(8)
     @Test
@@ -185,7 +199,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal {
     @Test
     void allOtherQueries_preFetch_journalAt() throws Exception {
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class).withMode(BarbelMode.BITEMPORAL).build();
-        assertEquals(4, core.retrieve(BarbelQueries.journalAt("someSome", LocalDateTime.now())).size());
+        assertEquals(4, core.retrieve(BarbelQueries.journalAt("someSome", BarbelHistoContext.getBarbelClock().now())).size());
     }
     @Order(10)
     @Test

--- a/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQueryBitemporal_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQueryBitemporal_SuiteTest.java
@@ -2,8 +2,6 @@ package org.projectbarbel.histo.suite.persistent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.projectbarbel.histo.BarbelHisto;
@@ -23,7 +21,7 @@ public class BarbelHistoCore_MultiUpdate_andQueryBitemporal_SuiteTest
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class)
                 .withMode(BarbelMode.BITEMPORAL).build();
         DefaultDocument pojo = new DefaultDocument("someOther", "some data");
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         assertEquals(25, ((BarbelHistoCore<DefaultDocument>) core).size());
     }
 }

--- a/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQuery_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_MultiUpdate_andQuery_SuiteTest.java
@@ -2,8 +2,6 @@ package org.projectbarbel.histo.suite.persistent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.projectbarbel.histo.BarbelHisto;
@@ -20,7 +18,7 @@ public class BarbelHistoCore_MultiUpdate_andQuery_SuiteTest extends BarbelHistoC
     public void addSomeMoreData() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
         DefaultPojo pojo = new DefaultPojo("someOther", "some data");
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         assertEquals(25, ((BarbelHistoCore<DefaultPojo>)core).size());
     }
 }

--- a/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_PersistenceConfig_Annotation_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/persistent/BarbelHistoCore_PersistenceConfig_Annotation_SuiteTest.java
@@ -3,8 +3,6 @@ package org.projectbarbel.histo.suite.persistent;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Test;
 import org.projectbarbel.histo.BarbelHisto;
 import org.projectbarbel.histo.pojos.PojoWOPersistenceConfig;
@@ -20,7 +18,7 @@ public class BarbelHistoCore_PersistenceConfig_Annotation_SuiteTest {
     public void testSavePojoInBitemporal() throws Exception {
         BarbelHisto<PojoWOPersistenceConfig> core = BTExecutionContext.INSTANCE.barbel(PojoWOPersistenceConfig.class).build();
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save(EnhancedRandom.random(PojoWOPersistenceConfig.class), LocalDate.now(), LocalDate.MAX));
+                () -> core.save(EnhancedRandom.random(PojoWOPersistenceConfig.class)));
         assertTrue(exc.getMessage().contains("@PersistenceConfig"));
     }
 

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_CQIndexing_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_CQIndexing_SuiteTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import java.io.IOException;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelMode;
 import org.projectbarbel.histo.BarbelQueries;
@@ -89,8 +90,9 @@ public class BarbelHistoCore_CQIndexing_SuiteTest {
                     return backbone;
                 })
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
-        T saved = (T)core.save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX).getUpdateRequest();
+        ZonedDateTime from = BarbelHistoContext.getBarbelClock().now();
+        core.save(pojo,from);
+        T saved = (T)core.save(pojo, from.plusDays(1)).getUpdateRequest();
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal object = (Bitemporal)core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         Bitemporal byPK = (Bitemporal)core.retrieve((Query<T>) equal(VERSION_ID_PK, (String)object.getBitemporalStamp().getVersionId())).stream().findFirst().get();
@@ -114,8 +116,9 @@ public class BarbelHistoCore_CQIndexing_SuiteTest {
                     return backbone;
                 }).withMode(BarbelMode.BITEMPORAL)
                 .build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
-        T saved = (T)core.save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX).getUpdateRequest();
+        ZonedDateTime from = BarbelHistoContext.getBarbelClock().now();
+        core.save(pojo, from);
+        T saved = (T)core.save(pojo, from.plusDays(1)).getUpdateRequest();
         assertEquals(3, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal object = (Bitemporal)core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         Bitemporal byPK = (Bitemporal)core.retrieve((Query<T>) equal(VERSION_ID_PK, (String)object.getBitemporalStamp().getVersionId())).stream().findFirst().get();

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_Contracts_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_Contracts_SuiteTest.java
@@ -7,7 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -24,6 +24,7 @@ import org.projectbarbel.histo.model.BitemporalStamp;
 import org.projectbarbel.histo.model.BitemporalVersion;
 import org.projectbarbel.histo.model.DefaultDocument;
 import org.projectbarbel.histo.model.DefaultPojo;
+import org.projectbarbel.histo.model.EffectivePeriod;
 import org.projectbarbel.histo.pojos.PrimitivePrivatePojo;
 import org.projectbarbel.histo.suite.BTExecutionContext;
 import org.projectbarbel.histo.suite.extensions.BTTestStandard;
@@ -49,7 +50,7 @@ public class BarbelHistoCore_Contracts_SuiteTest {
     public void testSave() throws Exception {
         BarbelHisto<String> core = BarbelHistoBuilder.barbel().build();
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save("some", LocalDate.now(), LocalDate.MAX));
+                () -> core.save("some"));
         assertTrue(exc.getMessage().contains("@DocumentId"));
     }
 
@@ -57,7 +58,7 @@ public class BarbelHistoCore_Contracts_SuiteTest {
     public void testSaveBitemporalVersion() throws Exception {
         BarbelHisto<BitemporalVersion> core = BTExecutionContext.INSTANCE.barbel(BitemporalVersion.class).build();
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save(new BitemporalVersion(BitemporalStamp.createActive(), EnhancedRandom.random(DefaultPojo.class)), LocalDate.now(), LocalDate.MAX));
+                () -> core.save(new BitemporalVersion(BitemporalStamp.createActive(), EnhancedRandom.random(DefaultPojo.class))));
         assertTrue(exc.getMessage().contains("BitemporalVersion cannot be used in BarbelMode.POJO"));
     }
     
@@ -65,7 +66,7 @@ public class BarbelHistoCore_Contracts_SuiteTest {
     public void testSaveBitemporalInModePOJO() throws Exception {
         BarbelHisto<DefaultDocument> core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class).build();
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save(new DefaultDocument("some", "bitemporal"), LocalDate.now(), LocalDate.MAX));
+                () -> core.save(new DefaultDocument("some", "bitemporal")));
         assertTrue(exc.getMessage().contains("don't use Bitemporal.class"));
     }
     
@@ -73,7 +74,7 @@ public class BarbelHistoCore_Contracts_SuiteTest {
     public void testSave_LocalDatesInvalid() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save(EnhancedRandom.random(DefaultPojo.class), LocalDate.MAX, LocalDate.now()));
+                () -> core.save(EnhancedRandom.random(DefaultPojo.class),EffectivePeriod.INFINITE,ZonedDateTime.now()));
         assertTrue(exc.getMessage().contains("from date"));
     }
 
@@ -81,7 +82,7 @@ public class BarbelHistoCore_Contracts_SuiteTest {
     public void testSavePojoInBitemporal() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).withMode(BarbelMode.BITEMPORAL).build();
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save(EnhancedRandom.random(DefaultPojo.class), LocalDate.now(), LocalDate.MAX));
+                () -> core.save(EnhancedRandom.random(DefaultPojo.class)));
         assertTrue(exc.getMessage().contains("don't forget"));
     }
     
@@ -94,7 +95,7 @@ public class BarbelHistoCore_Contracts_SuiteTest {
                 .build();
         SomePojo pojo = EnhancedRandom.random(SomePojo.class);
         Exception exc = assertThrows(IllegalArgumentException.class,
-                () -> core.save(pojo, LocalDate.now(), LocalDate.MAX));
+                () -> core.save(pojo));
         assertTrue(exc.getMessage().contains("@PersistenceConfig"));
     }
     
@@ -102,16 +103,16 @@ public class BarbelHistoCore_Contracts_SuiteTest {
     @SuppressWarnings("unused")
     private static Stream<Arguments> nullableParameters() {
         return Stream.of(
-                Arguments.of(EnhancedRandom.random(PrimitivePrivatePojo.class), LocalDate.now(), null),
-                Arguments.of(EnhancedRandom.random(PrimitivePrivatePojo.class), null, LocalDate.now()),
-                Arguments.of(null, LocalDate.now(), LocalDate.MAX),
-                Arguments.of(new PrimitivePrivatePojo(), LocalDate.now(), LocalDate.MAX)
+                Arguments.of(EnhancedRandom.random(PrimitivePrivatePojo.class), ZonedDateTime.now(), null),
+                Arguments.of(EnhancedRandom.random(PrimitivePrivatePojo.class), null, ZonedDateTime.now()),
+                Arguments.of(null, ZonedDateTime.now(), EffectivePeriod.INFINITE),
+                Arguments.of(new PrimitivePrivatePojo(), ZonedDateTime.now(), EffectivePeriod.INFINITE)
                 );
     }
     
     @ParameterizedTest
     @MethodSource("nullableParameters")
-    public <T> void testSaveParameter(T pojo, LocalDate from, LocalDate until) {
+    public <T> void testSaveParameter(T pojo, ZonedDateTime from, ZonedDateTime until) {
         BarbelHisto<T> core = BarbelHistoBuilder.barbel().build();
         assertThrows(IllegalArgumentException.class, ()->core.save(pojo, from, until));
     }

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_JournalTimeshift_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_JournalTimeshift_SuiteTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
@@ -35,7 +37,7 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @BeforeEach
     public void setup() {
         core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay().atZone(ZoneId.of("Z")));
     }
 
     @AfterAll
@@ -46,7 +48,7 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @Test
     public void testRetrieve() throws Exception {
         DefaultPojo pojo = EnhancedRandom.random(DefaultPojo.class);
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         assertEquals(1,
                 core.retrieve(and(BarbelQueries.all(pojo.getDocumentId()), BarbelQueries.all(pojo.getDocumentId())))
                         .size());
@@ -55,7 +57,7 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @Test
     public void testSave() throws Exception {
         DefaultPojo pojo = EnhancedRandom.random(DefaultPojo.class);
-        assertNotNull(core.save(pojo, LocalDate.now(), LocalDate.MAX));
+        assertNotNull(core.save(pojo));
     }
 
     //// @formatter:off
@@ -69,16 +71,16 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @Test
     public void testSave_twoVersions_case_1() {
 
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay().atZone(ZoneId.of("Z")));
 
         DefaultPojo pojo = EnhancedRandom.random(DefaultPojo.class);
-        core.save(pojo, BarbelHistoContext.getBarbelClock().today(), LocalDate.MAX);
+        core.save(pojo, BarbelHistoContext.getBarbelClock().now());
         DefaultPojo saveForLater = core.retrieveOne(BarbelQueries.effectiveNow(pojo.getDocumentId()));
 
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 10).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 10).atStartOfDay().atZone(ZoneId.of("Z")));
 
         pojo.setData("some new data");
-        core.save(pojo, BarbelHistoContext.getBarbelClock().today(), LocalDate.MAX);
+        core.save(pojo, BarbelHistoContext.getBarbelClock().now());
 
         // checking complete archive
         List<DefaultPojo> all = core.retrieve(BarbelQueries.all(pojo.getDocumentId()),
@@ -89,28 +91,28 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
         List<DefaultPojo> allInactive = core.retrieve(BarbelQueries.allInactive(pojo.getDocumentId()),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         assertEquals(1, allInactive.stream().count());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(4),
+        assertEquals(BarbelHistoContext.getBarbelClock().now().minusDays(4),
                 ((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().isInfinite());
 
         // checking active journal
         List<DefaultPojo> result = core.retrieve(BarbelQueries.allActive(pojo.getDocumentId()),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         assertEquals(2, result.stream().count());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(4),
+        assertEquals(BarbelHistoContext.getBarbelClock().now().minusDays(4),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(BarbelHistoContext.getBarbelClock().today(),
+        assertEquals(BarbelHistoContext.getBarbelClock().now(),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(BarbelHistoContext.getBarbelClock().today(),
+        assertEquals(BarbelHistoContext.getBarbelClock().now(),
                 ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().isInfinite());
 
         // introducing time shift
         System.out.println(core.prettyPrintJournal(pojo.getDocumentId()));
         String backboneJournalPriorTimeShift = core.prettyPrintJournal(pojo.getDocumentId());
 
         DocumentJournal timeshift = core.timeshift(pojo.getDocumentId(),
-                BarbelHistoContext.getBarbelClock().today().minusDays(1).atStartOfDay());
+                BarbelHistoContext.getBarbelClock().now().minusDays(1));
 
         assertNotNull(timeshift.read().effectiveNow());
         assertTrue(timeshift.read().activeVersions().size() == 1);
@@ -134,19 +136,21 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @Test
     public void testSave_twoVersions_case_3() {
 
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay().atZone(ZoneId.of("Z")));
 
         // saving two versions
         DefaultPojo pojo = EnhancedRandom.random(DefaultPojo.class);
-        core.save(pojo, BarbelHistoContext.getBarbelClock().today().minusDays(100),
-                BarbelHistoContext.getBarbelClock().today().minusDays(8));
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
+        core.save(pojo, now.minusDays(100),
+                now.minusDays(8));
         pojo.setData("some new data");
-        core.save(pojo, BarbelHistoContext.getBarbelClock().today().minusDays(8), LocalDate.MAX);
+        core.save(pojo, now.minusDays(8));
 
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 10).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 10).atStartOfDay().atZone(ZoneId.of("Z")));
+        now = BarbelHistoContext.getBarbelClock().now();
 
         pojo.setData("some more data");
-        core.save(pojo, BarbelHistoContext.getBarbelClock().today(), LocalDate.MAX);
+        core.save(pojo, now);
 
         // checking complete archive
         System.out.println(core.prettyPrintJournal(pojo.getDocumentId()));
@@ -158,26 +162,26 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
         List<DefaultPojo> allInactive = core.retrieve(BarbelQueries.allInactive(pojo.getDocumentId()),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         assertEquals(1, allInactive.stream().count());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(12),
+        assertEquals(now.minusDays(12),
                 ((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().isInfinite());
         assertEquals("some new data", allInactive.get(0).getData());
 
         // checking active journal
         List<DefaultPojo> result = core.retrieve(BarbelQueries.allActive(pojo.getDocumentId()),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         assertEquals(3, result.stream().count());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(104),
+        assertEquals(now.minusDays(104),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(12),
+        assertEquals(now.minusDays(12),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(12),
+        assertEquals(now.minusDays(12),
                 ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(BarbelHistoContext.getBarbelClock().today(),
+        assertEquals(now,
                 ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(BarbelHistoContext.getBarbelClock().today(),
+        assertEquals(now,
                 ((Bitemporal) result.get(2)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) result.get(2)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) result.get(2)).getBitemporalStamp().getEffectiveTime().isInfinite());
         assertEquals("some more data", result.get(2).getData());
 
         List<DefaultPojo> effectiveNow = core.retrieve(BarbelQueries.effectiveNow(pojo.getDocumentId()),
@@ -187,14 +191,14 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
 
         List<DefaultPojo> effectiveYesterday = core.retrieve(
                 BarbelQueries.effectiveAt(pojo.getDocumentId(),
-                        BarbelHistoContext.getBarbelClock().today().minusDays(1)),
+                        now.minusDays(1)),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         DefaultPojo effecive2 = effectiveYesterday.stream().findFirst().get();
         assertEquals("some new data", effecive2.getData());
 
         // shifting time back to original journal
         DocumentJournal shift = core.timeshift(pojo.getDocumentId(),
-                BarbelHistoContext.getBarbelClock().now().toLocalDateTime().minusDays(2));
+                now.minusDays(2));
 
         // should only be two active
         assertEquals(2, shift.read().activeVersions().size());
@@ -202,13 +206,13 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
         result = shift.read().activeVersions();
 
         // should have old initial effective periods
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(104),
+        assertEquals(now.minusDays(104),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(12),
+        assertEquals(now.minusDays(12),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(BarbelHistoContext.getBarbelClock().today().minusDays(12),
+        assertEquals(now.minusDays(12),
                 ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().isInfinite());
 
         // timeshift never has inactive versions
         assertEquals(0, shift.read().inactiveVersions().size());
@@ -218,9 +222,9 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @Test
     public void testSave_AlwaysCopies() {
         DefaultPojo pojo = EnhancedRandom.random(DefaultPojo.class);
-        core.save(pojo, BarbelHistoContext.getBarbelClock().today().minusDays(100),
-                BarbelHistoContext.getBarbelClock().today().minusDays(8));
-        DocumentJournal shift = core.timeshift(pojo.getDocumentId(), LocalDate.of(2019, 2, 6).atStartOfDay());
+        core.save(pojo, BarbelHistoContext.getBarbelClock().now().minusDays(100),
+                BarbelHistoContext.getBarbelClock().now().minusDays(8));
+        DocumentJournal shift = core.timeshift(pojo.getDocumentId(), ZonedDateTime.parse("2019-02-06T00:00:00Z"));
         DefaultPojo copy = (DefaultPojo) shift.read().activeVersions().get(0);
         assertNotSame(copy, pojo);
         assertNotSame(((BarbelProxy) copy).getTarget(), pojo);
@@ -239,21 +243,21 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
     @Test
     public void testSave_twoVersions_case_4() {
 
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 6).atStartOfDay().atZone(ZoneId.of("Z")));
 
         // saving two versions
         DefaultPojo pojo = EnhancedRandom.random(DefaultPojo.class);
         String originalData = pojo.getData();
-        core.save(pojo, LocalDate.of(2018, 10, 1), LocalDate.of(2019, 2, 1));
+        core.save(pojo, ZonedDateTime.parse("2018-10-01T00:00:00Z"), ZonedDateTime.parse("2019-02-01T00:00:00Z"));
         pojo.setData("2nd Period");
-        core.save(pojo, LocalDate.of(2019, 2, 1), LocalDate.of(2019, 2, 6));
+        core.save(pojo, ZonedDateTime.parse("2019-02-01T00:00:00Z"), ZonedDateTime.parse("2019-02-06T00:00:00Z"));
         pojo.setData("3rd Period");
-        core.save(pojo, LocalDate.of(2019, 2, 6), LocalDate.MAX);
+        core.save(pojo, ZonedDateTime.parse("2019-02-06T00:00:00Z"));
 
-        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 10).atStartOfDay());
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDate.of(2019, 2, 10).atStartOfDay().atZone(ZoneId.of("Z")));
 
         pojo.setData("4td interrupting Period");
-        core.save(pojo, LocalDate.of(2019, 1, 25), LocalDate.of(2019, 2, 10));
+        core.save(pojo, ZonedDateTime.parse("2019-01-25T00:00:00Z"), ZonedDateTime.parse("2019-02-10T00:00:00Z"));
 
         // checking complete archive
         System.out.println(core.prettyPrintJournal(pojo.getDocumentId()));
@@ -265,17 +269,17 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
         List<DefaultPojo> allInactive = core.retrieve(BarbelQueries.allInactive(pojo.getDocumentId()),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         assertEquals(3, allInactive.stream().count());
-        assertEquals(LocalDate.of(2018, 10, 1),
+        assertEquals(ZonedDateTime.parse("2018-10-01T00:00:00Z"),
                 ((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.of(2019, 2, 1),
+        assertEquals(ZonedDateTime.parse("2019-02-01T00:00:00Z"),
                 ((Bitemporal) allInactive.get(0)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(LocalDate.of(2019, 2, 1),
+        assertEquals(ZonedDateTime.parse("2019-02-01T00:00:00Z"),
                 ((Bitemporal) allInactive.get(1)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.of(2019, 2, 6),
+        assertEquals(ZonedDateTime.parse("2019-02-06T00:00:00Z"),
                 ((Bitemporal) allInactive.get(1)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(LocalDate.of(2019, 2, 6),
+        assertEquals(ZonedDateTime.parse("2019-02-06T00:00:00Z"),
                 ((Bitemporal) allInactive.get(2)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) allInactive.get(2)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) allInactive.get(2)).getBitemporalStamp().getEffectiveTime().isInfinite());
         assertEquals(originalData, allInactive.get(0).getData());
         assertEquals("2nd Period", allInactive.get(1).getData());
         assertEquals("3rd Period", allInactive.get(2).getData());
@@ -284,39 +288,38 @@ public class BarbelHistoCore_JournalTimeshift_SuiteTest {
         List<DefaultPojo> result = core.retrieve(BarbelQueries.allActive(pojo.getDocumentId()),
                 BarbelQueryOptions.sortAscendingByEffectiveFrom());
         assertEquals(3, result.stream().count());
-        assertEquals(LocalDate.of(2018, 10, 1),
+        assertEquals(ZonedDateTime.parse("2018-10-01T00:00:00Z"),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.of(2019, 1, 25),
+        assertEquals(ZonedDateTime.parse("2019-01-25T00:00:00Z"),
                 ((Bitemporal) result.get(0)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(LocalDate.of(2019, 1, 25),
+        assertEquals(ZonedDateTime.parse("2019-01-25T00:00:00Z"),
                 ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.of(2019, 2, 10),
+        assertEquals(ZonedDateTime.parse("2019-02-10T00:00:00Z"),
                 ((Bitemporal) result.get(1)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(LocalDate.of(2019, 2, 10),
+        assertEquals(ZonedDateTime.parse("2019-02-10T00:00:00Z"),
                 ((Bitemporal) result.get(2)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX, ((Bitemporal) result.get(2)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) result.get(2)).getBitemporalStamp().getEffectiveTime().isInfinite());
         assertEquals(originalData, result.get(0).getData());
         assertEquals("4td interrupting Period", result.get(1).getData());
         assertEquals("3rd Period", result.get(2).getData());
 
         // time shift
-        DocumentJournal shift = core.timeshift(pojo.getDocumentId(), LocalDate.of(2019, 2, 8).atStartOfDay());
+        DocumentJournal shift = core.timeshift(pojo.getDocumentId(), LocalDate.of(2019, 2, 8).atStartOfDay().atZone(ZoneId.of("Z")));
         List<DefaultPojo> shiftedJournal = shift.read().activeVersions();
 
         // the initial journal
         assertEquals(3, shiftedJournal.stream().count());
-        assertEquals(LocalDate.of(2018, 10, 1),
+        assertEquals(ZonedDateTime.parse("2018-10-01T00:00:00Z"),
                 ((Bitemporal) shiftedJournal.get(0)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.of(2019, 2, 1),
+        assertEquals(ZonedDateTime.parse("2019-02-01T00:00:00Z"),
                 ((Bitemporal) shiftedJournal.get(0)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(LocalDate.of(2019, 2, 1),
+        assertEquals(ZonedDateTime.parse("2019-02-01T00:00:00Z"),
                 ((Bitemporal) shiftedJournal.get(1)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.of(2019, 2, 6),
+        assertEquals(ZonedDateTime.parse("2019-02-06T00:00:00Z"),
                 ((Bitemporal) shiftedJournal.get(1)).getBitemporalStamp().getEffectiveTime().until());
-        assertEquals(LocalDate.of(2019, 2, 6),
+        assertEquals(ZonedDateTime.parse("2019-02-06T00:00:00Z"),
                 ((Bitemporal) shiftedJournal.get(2)).getBitemporalStamp().getEffectiveTime().from());
-        assertEquals(LocalDate.MAX,
-                ((Bitemporal) shiftedJournal.get(2)).getBitemporalStamp().getEffectiveTime().until());
+        assertTrue(((Bitemporal) shiftedJournal.get(2)).getBitemporalStamp().getEffectiveTime().isInfinite());
 
         // all active
         assertEquals(BitemporalObjectState.ACTIVE,

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_Memory_Policy_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_Memory_Policy_SuiteTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -62,8 +62,8 @@ public class BarbelHistoCore_Memory_Policy_SuiteTest {
             long time = new Date().getTime();
             for (Object pojo : pojos) {
                 core.save((Policy) pojo,
-                        BarbelTestHelper.randomLocalDate(LocalDate.of(2010, 1, 1), LocalDate.of(2015, 1, 1)),
-                        BarbelTestHelper.randomLocalDate(LocalDate.of(2015, 1, 2), LocalDate.of(2020, 1, 1)));
+                        BarbelTestHelper.randomLocalTime(ZonedDateTime.parse("2010-01-01T00:00:00Z"), ZonedDateTime.parse("2015-01-01T00:00:00Z")),
+                        BarbelTestHelper.randomLocalTime(ZonedDateTime.parse("2015-01-02T00:00:00Z"), ZonedDateTime.parse("2020-01-01T00:00:00Z")));
             }
             System.out.println("######### Barbel-Statistics #########");
             BigDecimal timetaken = new BigDecimal((new Date().getTime() - time)).divide(new BigDecimal(1000))

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_MultiUpdate_Bitemporal_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_MultiUpdate_Bitemporal_SuiteTest.java
@@ -2,8 +2,11 @@ package org.projectbarbel.histo.suite.standard;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -11,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelMode;
 import org.projectbarbel.histo.BarbelQueries;
@@ -27,188 +31,205 @@ public class BarbelHistoCore_MultiUpdate_Bitemporal_SuiteTest {
     @BeforeAll
     public static void setUo() {
         core = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class).withMode(BarbelMode.BITEMPORAL).build();
+        BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.now().atZone(ZoneId.of("Z")));
     }
-    
+
+    @AfterAll
+    public static void restartClock() {
+	    BarbelHistoContext.getBarbelClock().useSystemDefaultZoneClock();
+    }
+
     // @formatter:off
     @Order(1)
     @Test
     void update_1() throws Exception {
         DefaultDocument pojo = new DefaultDocument("someSome", "some data");
-        
-        // Now |---------------------------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
+	    // Now |---------------------------------| 20
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(0, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(2)
     @Test
     void update_2() throws Exception {
-    
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         // Now |---------------------------------| 20
         //      1|---------------|10
         //     |-|---------------|---------------| 20
         DefaultDocument pojo = new DefaultDocument("someSome", "changed");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(10));
+        core.save(pojo, now.plusDays(1), now.plusDays(10));
         assertEquals(4,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(1, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(3)
     @Test
     void update_3() throws Exception {
-
-        //     |-|---------------|---------------| 20
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
+	    //     |-|---------------|---------------| 20
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(5,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(3, core.retrieve(BarbelQueries.allInactive("someSome")).size());
-        
+
     }
-    
+
     @Order(4)
     @Test
     void update_4() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|-------------------------------| 20
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(6,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(4, core.retrieve(BarbelQueries.allInactive("someSome")).size());
-        
+
     }
-    
+
     @Order(5)
     @Test
     void update_5() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|-------------------------------| 20
         //     |---------------------------------| 20
         //     |---------------------------------| 20
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(7,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(6, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(6)
     @Test
     void update_6() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
        //     |---------------------------------| 20
        //     |-----------------| 10
        //     |-----------------|---------------| 20
        DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-       core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(10));
+       core.save(pojo, now, now.plusDays(10));
        assertEquals(9,((BarbelHistoCore<DefaultDocument>)core).size());
        assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
        assertEquals(7, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(7)
     @Test
     void update_7() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-----------------|---------------| 20
         //     |--------------------------------------------------| 100
         //     |--------------------------------------------------| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(100));
+        core.save(pojo, now, now.plusDays(100));
         assertEquals(10,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(9, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(8)
     @Test
     void update_8() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |---------------------------------------------------| 100
         //     |-|-----------------------------------------------|-| 100
         //     |-|-----------------------------------------------|-| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(99));
+        core.save(pojo, now.plusDays(1), now.plusDays(99));
         assertEquals(13,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(10, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(9)
     @Test
     void update_9() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|-----------------------------------------------|-| 100
         //       |--| 3
         //     |-|--|--------------------------------------------|-| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(3));
+        core.save(pojo, now.plusDays(1), now.plusDays(3));
         assertEquals(15,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(11, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(10)
     @Test
     void update_10() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--------------------------------------------|-| 100
         //         3|--|5
         //     |-|--|--|-----------------------------------------|-| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(3), LocalDate.now().plusDays(5));
+        core.save(pojo, now.plusDays(3), now.plusDays(5));
         assertEquals(17,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(12, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(11)
     @Test
     void update_11() throws Exception {
-        //     |-|--|--|-----------------------------------------|-| 100
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
+	    //     |-|--|--|-----------------------------------------|-| 100
         //            5|--|7
         //     |-|--|--|--|--------------------------------------|-| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(5), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(5), now.plusDays(7));
         assertEquals(19,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(6, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(13, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(12)
     @Test
     void update_12() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--|--|--------------------------------------|-| 100
         //                |----------------------------------------| 100
         //     |-|--|--|--|----------------------------------------| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(7), LocalDate.now().plusDays(100));
+        core.save(pojo, now.plusDays(7), now.plusDays(100));
         assertEquals(20,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(15, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(13)
     @Test
     void update_13() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--|--|----------------------------------------| 100
         //        |------|
         //     |-||------||----------------------------------------| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(6));
+        core.save(pojo, now.plusDays(2), now.plusDays(6));
         assertEquals(23,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(18, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-        
+
     @Order(14)
     @Test
     void update_14() throws Exception {
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-||------||----------------------------------------| 100
         //        |-------|
         //     |-||-------|----------------------------------------| 100
         DefaultDocument pojo = new DefaultDocument("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(2), now.plusDays(7));
         assertEquals(24,((BarbelHistoCore<DefaultDocument>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(20, core.retrieve(BarbelQueries.allInactive("someSome")).size());

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_MultiUpdate_MAX_TestSuite.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_MultiUpdate_MAX_TestSuite.java
@@ -2,14 +2,16 @@ package org.projectbarbel.histo.suite.standard;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelQueries;
 import org.projectbarbel.histo.model.DefaultPojo;
+import org.projectbarbel.histo.model.EffectivePeriod;
 import org.projectbarbel.histo.suite.BTExecutionContext;
 import org.projectbarbel.histo.suite.extensions.BTTestStandard;
 
@@ -20,28 +22,28 @@ public class BarbelHistoCore_MultiUpdate_MAX_TestSuite {
     void embeddedOverlap_Max() throws Exception {
         BarbelHisto<DefaultPojo> core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
         DefaultPojo pojo = new DefaultPojo("somePojo", "some data");
-        
-        // Now |---------------------------------| MAX
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+	    ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
+	    // Now |---------------------------------| INFINITE
+        core.save(pojo, now, EffectivePeriod.INFINITE);
         assertEquals(1, core.retrieve(BarbelQueries.allActive("somePojo")).size());
         assertEquals(0, core.retrieve(BarbelQueries.allInactive("somePojo")).size());
-        
-        // Now |---------------------------------| MAX
-        //      |--------------------------------| Max
-        //     ||--------------------------------| Max
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.MAX);
+
+        // Now |---------------------------------| INFINITE
+        //      |--------------------------------| INFINITE
+        //     ||--------------------------------| INFINITE
+        core.save(pojo, now.plusDays(1), EffectivePeriod.INFINITE);
         assertEquals(3,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("somePojo")).size());
         assertEquals(1, core.retrieve(BarbelQueries.allInactive("somePojo")).size());
-        
-        //     ||--------------------------------| Max
-        //        5|-----------------------------| MAX
-        //     ||--|-----------------------------| Max
-        core.save(pojo, LocalDate.now().plusDays(5), LocalDate.MAX);
+
+        //     ||--------------------------------| INFINITE
+        //        5|-----------------------------| INFINITE
+        //     ||--|-----------------------------| INFINITE
+        core.save(pojo, now.plusDays(5), EffectivePeriod.INFINITE);
         assertEquals(5,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("somePojo")).size());
         assertEquals(2, core.retrieve(BarbelQueries.allInactive("somePojo")).size());
-        
+
     }
 
 }

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_MultiUpdate_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_MultiUpdate_SuiteTest.java
@@ -2,8 +2,11 @@ package org.projectbarbel.histo.suite.standard;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -11,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelQueries;
 import org.projectbarbel.histo.model.DefaultPojo;
@@ -26,188 +30,205 @@ public class BarbelHistoCore_MultiUpdate_SuiteTest {
     @BeforeAll
     public static void setUo() {
         core = BTExecutionContext.INSTANCE.barbel(DefaultPojo.class).build();
+	    BarbelHistoContext.getBarbelClock().useFixedClockAt(LocalDateTime.now().atZone(ZoneId.of("Z")));
     }
-    
+
+    @AfterAll
+    public static void restartClock() {
+        BarbelHistoContext.getBarbelClock().useSystemDefaultZoneClock();
+    }
+
     // @formatter:off
     @Order(1)
     @Test
     void update_1() throws Exception {
         DefaultPojo pojo = new DefaultPojo("someSome", "some data");
-        
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         // Now |---------------------------------| 20
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(0, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(2)
     @Test
     void update_2() throws Exception {
-    
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         // Now |---------------------------------| 20
         //      1|---------------|10
         //     |-|---------------|---------------| 20
         DefaultPojo pojo = new DefaultPojo("someSome", "changed");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(10));
+        core.save(pojo, now.plusDays(1), now.plusDays(10));
         assertEquals(4,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(1, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(3)
     @Test
     void update_3() throws Exception {
-
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|---------------|---------------| 20
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
         DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(5,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(3, core.retrieve(BarbelQueries.allInactive("someSome")).size());
-        
+
     }
-    
+
     @Order(4)
     @Test
     void update_4() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|-------------------------------| 20
         //      1|-------------------------------| 20
         //     |-|-------------------------------| 20
         DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(20));
+        core.save(pojo, now.plusDays(1), now.plusDays(20));
         assertEquals(6,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(4, core.retrieve(BarbelQueries.allInactive("someSome")).size());
-        
+
     }
-    
+
     @Order(5)
     @Test
     void update_5() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|-------------------------------| 20
         //     |---------------------------------| 20
         //     |---------------------------------| 20
         DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(20));
+        core.save(pojo, now, now.plusDays(20));
         assertEquals(7,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(6, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(6)
     @Test
     void update_6() throws Exception {
-       //     |---------------------------------| 20
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
+        //     |---------------------------------| 20
        //     |-----------------| 10
        //     |-----------------|---------------| 20
            DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-       core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(10));
+       core.save(pojo, now, now.plusDays(10));
        assertEquals(9,((BarbelHistoCore<DefaultPojo>)core).size());
        assertEquals(2, core.retrieve(BarbelQueries.allActive("someSome")).size());
        assertEquals(7, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(7)
     @Test
     void update_7() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-----------------|---------------| 20
         //     |--------------------------------------------------| 100
         //     |--------------------------------------------------| 100
             DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now(), LocalDate.now().plusDays(100));
+        core.save(pojo, now, now.plusDays(100));
         assertEquals(10,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(1, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(9, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(8)
     @Test
     void update_8() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |---------------------------------------------------| 100
         //     |-|-----------------------------------------------|-| 100
         //     |-|-----------------------------------------------|-| 100
         DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(99));
+        core.save(pojo, now.plusDays(1), now.plusDays(99));
         assertEquals(13,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(3, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(10, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(9)
     @Test
     void update_9() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|-----------------------------------------------|-| 100
         //       |--| 3
         //     |-|--|--------------------------------------------|-| 100
             DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(1), LocalDate.now().plusDays(3));
+        core.save(pojo, now.plusDays(1), now.plusDays(3));
         assertEquals(15,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(11, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(10)
     @Test
     void update_10() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--------------------------------------------|-| 100
         //         3|--|5
         //     |-|--|--|-----------------------------------------|-| 100
             DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(3), LocalDate.now().plusDays(5));
+        core.save(pojo, now.plusDays(3), now.plusDays(5));
         assertEquals(17,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(12, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(11)
     @Test
     void update_11() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--|-----------------------------------------|-| 100
         //            5|--|7
         //     |-|--|--|--|--------------------------------------|-| 100
             DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(5), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(5), now.plusDays(7));
         assertEquals(19,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(6, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(13, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(12)
     @Test
     void update_12() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--|--|--------------------------------------|-| 100
         //                |----------------------------------------| 100
         //     |-|--|--|--|----------------------------------------| 100
         DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(7), LocalDate.now().plusDays(100));
+        core.save(pojo, now.plusDays(7), now.plusDays(100));
         assertEquals(20,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(15, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-    
+
     @Order(13)
     @Test
     void update_13() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-|--|--|--|----------------------------------------| 100
         //        |------|
         //     |-||------||----------------------------------------| 100
             DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(6));
+        core.save(pojo, now.plusDays(2), now.plusDays(6));
         assertEquals(23,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(5, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(18, core.retrieve(BarbelQueries.allInactive("someSome")).size());
     }
-        
+
     @Order(14)
     @Test
     void update_14() throws Exception {
+        ZonedDateTime now = BarbelHistoContext.getBarbelClock().now();
         //     |-||------||----------------------------------------| 100
         //        |-------|
         //     |-||-------|----------------------------------------| 100
         DefaultPojo pojo = new DefaultPojo("someSome", "changed again");
-        core.save(pojo, LocalDate.now().plusDays(2), LocalDate.now().plusDays(7));
+        core.save(pojo, now.plusDays(2), now.plusDays(7));
         assertEquals(24,((BarbelHistoCore<DefaultPojo>)core).size());
         assertEquals(4, core.retrieve(BarbelQueries.allActive("someSome")).size());
         assertEquals(20, core.retrieve(BarbelQueries.allInactive("someSome")).size());

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_PojoVariants_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_PojoVariants_SuiteTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,7 @@ public class BarbelHistoCore_PojoVariants_SuiteTest {
     public void setUp() {
         BTExecutionContext.INSTANCE.clearResources();
     }
-    
+
     @SuppressWarnings("unused")
     private static Stream<Arguments> createPojos() {
         return Stream.of(Arguments.of(EnhancedRandom.random(PrimitivePrivatePojo.class)),
@@ -63,7 +62,7 @@ public class BarbelHistoCore_PojoVariants_SuiteTest {
     @MethodSource("createPojos")
     public <T> void testSave(T pojo) {
         BarbelHisto<T> core = BTExecutionContext.INSTANCE.barbel(pojo.getClass()).build();
-        core.save(pojo, LocalDate.now(), LocalDate.MAX);
+        core.save(pojo);
         assertEquals(1, core.retrieve(BarbelQueries.all()).stream().count());
         Bitemporal record = (Bitemporal) core.retrieve(BarbelQueries.all()).stream().findFirst().get();
         assertEquals(((BarbelProxy)record).getTarget(), pojo);

--- a/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_ShadowCollectionPersistence_SuiteTest.java
+++ b/src/test/java/org/projectbarbel/histo/suite/standard/BarbelHistoCore_ShadowCollectionPersistence_SuiteTest.java
@@ -2,7 +2,6 @@ package org.projectbarbel.histo.suite.standard;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -13,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectbarbel.histo.BarbelHisto;
+import org.projectbarbel.histo.BarbelHistoContext;
 import org.projectbarbel.histo.BarbelHistoCore;
 import org.projectbarbel.histo.BarbelMode;
 import org.projectbarbel.histo.BarbelQueries;
@@ -25,6 +25,7 @@ import org.projectbarbel.histo.event.EventType.UpdateFinishedEvent;
 import org.projectbarbel.histo.model.Bitemporal;
 import org.projectbarbel.histo.model.BitemporalStamp;
 import org.projectbarbel.histo.model.DefaultDocument;
+import org.projectbarbel.histo.model.EffectivePeriod;
 import org.projectbarbel.histo.suite.BTExecutionContext;
 import org.projectbarbel.histo.suite.extensions.BTTestStandard;
 
@@ -45,10 +46,10 @@ public class BarbelHistoCore_ShadowCollectionPersistence_SuiteTest {
         BarbelHisto<DefaultDocument> barbel = BTExecutionContext.INSTANCE.barbel(DefaultDocument.class)
                 .withMode(BarbelMode.BITEMPORAL).withSynchronousEventListener(new ShadowCollectionListener()).build();
         DefaultDocument pojo = new DefaultDocument("someId", BitemporalStamp.createActive("someId"), "some data");
-        barbel.save(pojo, LocalDate.now(), LocalDate.MAX);
+        barbel.save(pojo);
         assertEquals(1, shadow.size());
         pojo.setData("some changes");
-        barbel.save(pojo, LocalDate.now().plusDays(2), LocalDate.MAX);
+        barbel.save(pojo, BarbelHistoContext.getBarbelClock().now().plusDays(2), EffectivePeriod.INFINITE);
         assertEquals(3, shadow.size());
     }
 


### PR DESCRIPTION
The `EffectivePeriod.from` and `EffectivePeriod.until` were changed to use `ZonedDateTime` instead of `LocalDate`.
From this basic change all other changes were derived, while trying to minimize the delta for the first commit).
Instead of using `LocalDate.MAX`, consistently `EffectivePeriod.INFINITE` was used. The following items may require additional review:

 - `EffectivePeriod.INFINITE` is defined with an arbitrary time instead of a MAX value. This could be changed to make the library more robust.
   Since I don't know the reason for the chosen Date, I did not change it.
 - `EmbeddingJournalUpdateStrategy` substracts now one millisecond instead of one day. The reason for not using nanoseconds was that the
   query method on `BarbelQueries.CREATED_AT` and `BarbelQueries.INACTIVATED_AT` were using millisecond granularity.
 - The test cases were written with a granularity of Day in mind, some additional test cases should check on millisecond granularity.
 - Three default methods were added to the `BarbelHisto` interface to simplify some common use cases (saving object effective from now to infinity,
   saving objects effective from a specified time to infinity and saving object using an `EffectivePeriod`)

There are still some test cases failing that need to be looked at.