### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ deploy:
   - target/barbelhisto-core-$project_version-sources.jar
   - target/barbelhisto-core-$project_version-javadoc.jar
   name: $project_version
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.